### PR TITLE
Fixup TCP_KEEPCNT

### DIFF
--- a/libkeepalive.c
+++ b/libkeepalive.c
@@ -58,7 +58,7 @@ void _init(void) {
     opt.tcp_keepidle = atoi(env_tcp_keepidle);
 
   if (env_tcp_keepcnt)
-    opt.tcp_keepidle = atoi(env_tcp_keepcnt);
+    opt.tcp_keepcnt = atoi(env_tcp_keepcnt);
 
   if (env_tcp_keepintvl)
     opt.tcp_keepintvl = atoi(env_tcp_keepintvl);

--- a/libkeepalive_listen.c
+++ b/libkeepalive_listen.c
@@ -56,7 +56,7 @@ void _init(void) {
     opt.tcp_keepidle = atoi(env_tcp_keepidle);
 
   if (env_tcp_keepcnt)
-    opt.tcp_keepidle = atoi(env_tcp_keepcnt);
+    opt.tcp_keepcnt = atoi(env_tcp_keepcnt);
 
   if (env_tcp_keepintvl)
     opt.tcp_keepintvl = atoi(env_tcp_keepintvl);


### PR DESCRIPTION
Previously TCP_KEEPCNT environment variable was being read into keepidle setting